### PR TITLE
Podspec missing configuration to correctly compile and show stub payment sheet (and other issues)

### DIFF
--- a/ApplePayStubs.podspec
+++ b/ApplePayStubs.podspec
@@ -11,8 +11,9 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/stripe/ApplePayStubs.git", :tag => "v#{s.version}" }
   s.source_files = "Classes", "Classes/**/*.{h,m}"
-  s.exclude_files= "Classes/Exclude"
-  s.weak_framework    = "PassKit"
+  s.resource     =  "Classes/STPTestPaymentSummaryViewController.xib"
+  s.exclude_files   = "Classes/Exclude"
+  s.weak_framework  = "PassKit"
   s.requires_arc = true
   s.prefix_header_contents = "#define STRIPE_ENABLE_APPLEPAY"
 end


### PR DESCRIPTION
The Podspec was missing a few details which causes problems when we integrated.

1) The platform version was set to 8.0 which stopped us from being able to integrate it into our project which will be selectively making Apple Pay available to devices on iOS8.1 and above, whilst still supporting 7.0 devices. 
2) STPTestPaymentSummaryViewController.xib was missing which causes this view controller to show up blank when presented
3) PassKit was included as a strong (not weak_framework) which as with issue 1) blocked us setting our Target to iOS7.0
4) STRIPE_ENABLE_APPLEPAY was not defined which caused integration issues as well. 
