### PR TITLE
Test Addresses with ISO 3166-1 alpha-2 country codes

### DIFF
--- a/ApplePayStubs/STPTestAddressStore.m
+++ b/ApplePayStubs/STPTestAddressStore.m
@@ -28,7 +28,8 @@
                 @"city": @"Cupertino",
                 @"state": @"CA",
                 @"zip": @"95014",
-                @"country": @"US",
+                @"country": @"United States",
+                @"countryCode": @"US",
                 @"phone": @"888 555-1212",
             },
             @{
@@ -38,7 +39,8 @@
                 @"city": @"Washington",
                 @"state": @"DC",
                 @"zip": @"20500",
-                @"country": @"US",
+                @"country": @"United States",
+                @"countryCode": @"US",
                 @"phone": @"888 867-5309",
             },
             @{
@@ -48,7 +50,8 @@
                 @"city": @"London",
                 @"state": @"",
                 @"zip": @"",
-                @"country": @"UK",
+                @"country": @"United Kingdom",
+                @"countryCode": @"GB",
                 @"phone": @"07 987 654 321",
             },
         ];
@@ -67,8 +70,8 @@
 
     // address
     ABMutableMultiValueRef address = ABMultiValueCreateMutable(kABDictionaryPropertyType);
-    CFStringRef keys[5];
-    CFStringRef values[5];
+    CFStringRef keys[6];
+    CFStringRef values[6];
     CFIndex numValues = 0;
 
     if (!obscure) {
@@ -83,7 +86,10 @@
     values[numValues++] = CFBridgingRetain(item[@"zip"]);
     keys[numValues] = kABPersonAddressCountryKey;
     values[numValues++] = CFBridgingRetain(item[@"country"]);
+    keys[numValues] = kABPersonAddressCountryCodeKey;
+    values[numValues++] = CFBridgingRetain(item[@"countryCode"]);
 
+    
     CFDictionaryRef aDict = CFDictionaryCreate(
         kCFAllocatorDefault, (const void **)keys, (const void **)values, numValues, &kCFCopyStringDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 


### PR DESCRIPTION
Adding valid ISO 3166-1 alpha-2 country code fields to test addresses, also changing country to use full english country string rather than two letter codes. 

Country codes are mapped to ABRecord's kABPersonAddressCountryCodeKey value when passed to payment sheet. 