### PR TITLE
Mirroring Native Apple Pay Sheet's PKPaymentAuthorizationViewControllerDelegate calling

### DIFF
--- a/ApplePayStubs/STPTestPaymentSummaryViewController.m
+++ b/ApplePayStubs/STPTestPaymentSummaryViewController.m
@@ -79,7 +79,8 @@ NSString *const STPTestPaymentSectionTitlePayment = @"Payment";
     [self updateSectionTitles];
     [self.tableView registerClass:[STPTestPaymentSummaryItemCell class] forCellReuseIdentifier:STPTestPaymentAuthorizationSummaryItemIdentifier];
     [self.tableView registerClass:[STPTestPaymentDataCell class] forCellReuseIdentifier:STPTestPaymentAuthorizationTestDataIdentifier];
-    if (self.paymentRequest.requiredShippingAddressFields != PKAddressFieldNone) {
+    // Real Apple Pay sheet only calls delegate when postal address is in requiredShippingAddressFields
+    if (self.paymentRequest.requiredShippingAddressFields & PKAddressFieldPostalAddress) {
         [self didSelectShippingAddress];
     }
 }
@@ -264,7 +265,12 @@ NSString *const STPTestPaymentSectionTitlePayment = @"Payment";
     id<STPTestDataStore> store = [self storeForSection:self.sectionTitles[indexPath.section]];
     STPTestDataTableViewController *controller = [[STPTestDataTableViewController alloc] initWithStore:store];
     if (store == self.shippingAddressStore) {
-        controller.callback = ^void(id item) { [self didSelectShippingAddress]; };
+        controller.callback = ^void(id item) {
+            // Real Apple Pay sheet only calls delegate when postal address is in requiredShippingAddressFields
+            if (self.paymentRequest.requiredShippingAddressFields & PKAddressFieldPostalAddress) {
+                [self didSelectShippingAddress];
+            }
+        };
     }
     if (store == self.shippingMethodStore) {
         controller.callback = ^void(id item) {


### PR DESCRIPTION
This PR replicates behaviour of the real ApplePay sheet around calling of the PKPaymentAuthorizationViewControllerDelegate delegate. 

Specifically this PR changes the STPTestPaymentSummaryViewController to only call  `- (void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller
                   didSelectShippingMethod:(PKShippingMethod *)shippingMethod
                                completion:(void (^)(PKPaymentAuthorizationStatus status,
                                                     NSArray *summaryItems))completion` on its delegate if the postal address field (PKAddressFieldPostalAddress) is in -[PKPaymentRequest requiredShippingAddressFields].
