### PR TITLE
changing xib to build with project deployment target

### DIFF
--- a/ApplePayStubs/STPTestPaymentSummaryViewController.xib
+++ b/ApplePayStubs/STPTestPaymentSummaryViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6245" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment version="2048" defaultVersion="1808" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6238"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="STPTestPaymentSummaryViewController">
@@ -43,7 +43,7 @@
                 </activityIndicatorView>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="8" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="7xh-V2-Cso">
                     <rect key="frame" x="0.0" y="30" width="298" height="329"/>
-                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="yHS-Xa-uTm"/>
                         <outlet property="delegate" destination="-1" id="Dey-iQ-ERm"/>


### PR DESCRIPTION
Modifying xib to build with the project deployment target avoids warnings for projects with deployment targets of 8.0+.

The warning is presented below:

```
/Pods/ApplePayStubs/ApplePayStubs/STPTestPaymentSummaryViewController.xib:global: warning: This file is set to build for a version older than the project deployment target. Functionality may be limited. [9]
```