### PR TITLE
Support for optionally including country code in selected address

### DIFF
--- a/ApplePayStubs/STPTestAddressStore.m
+++ b/ApplePayStubs/STPTestAddressStore.m
@@ -83,9 +83,10 @@
     values[numValues++] = CFBridgingRetain(item[@"zip"]);
     keys[numValues] = kABPersonAddressCountryKey;
     values[numValues++] = CFBridgingRetain(item[@"country"]);
-    keys[numValues] = kABPersonAddressCountryCodeKey;
-    values[numValues++] = CFBridgingRetain(item[@"countryCode"]);
-
+    if (item[@"countryCode"]) {
+        keys[numValues] = kABPersonAddressCountryCodeKey;
+        values[numValues++] = CFBridgingRetain(item[@"countryCode"]);
+    }
     
     CFDictionaryRef aDict = CFDictionaryCreate(
         kCFAllocatorDefault, (const void **)keys, (const void **)values, numValues, &kCFCopyStringDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);


### PR DESCRIPTION
Without this change, using the old ABRecordRef contactForSelectedItemObscure implementation causes a crash if countryCode isn't present in the selected address. 
